### PR TITLE
adjusted build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,11 @@ sourceSets {
 
 task fatJar(type: Jar) {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
-    baseName = project.name + '-all'
+    archiveFileName = "${project.name}-all.jar"
     from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
-    with jar
+    into('') {
+        from(sourceSets.main.output) // include classes from this project
+    }
 }
 
 compileJava {


### PR DESCRIPTION
It gave some errors on my mac, that why I added this part.

The into method sets the destination directory to the root of the JAR file (i.e., the top level). The from method includes all the compiled classes from the "main" source set.